### PR TITLE
Clarify high-scoring story retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hacker News 500 Telegram Bot
 
-This is a Rust program that fetches the top 500 stories from Hacker News and
+This is a Rust program that fetches the newest stories with at least 500 points from Hacker News and
 sends them to a Telegram chat.
 
 It deduplicates the stories and only sends the new ones.
@@ -38,7 +38,7 @@ The following environment variables are used to configure the bot:
 The project is structured as follows:
 
 *   `src/main.rs`: The entry point of the application.
-*   `src/client.rs`: Handles fetching the top 500 stories from Hacker News.
+*   `src/client.rs`: Handles fetching the newest stories with at least 500 points from Hacker News.
 *   `src/broadcast.rs`: Handles sending the stories to the Telegram chat.
 *   `src/config.rs`: Handles loading the configuration from the environment.
 *   `src/models.rs`: Contains the data models for the Hacker News stories.

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,4 @@
-//! This module is responsible for fetching the top 500 stories from Hacker News.
+//! This module is responsible for fetching new stories from Hacker News that have ≥500 points.
 
 #![deny(clippy::all)]
 
@@ -6,7 +6,7 @@ use bytes::Bytes;
 
 const HN_500_URL: &str = "https://hnrss.org/newest?points=500";
 
-/// Fetches the top 500 stories from Hacker News.
+/// Fetches new stories from Hacker News that have ≥500 points.
 pub async fn fetch_hacker_news(client: &reqwest::Client) -> Result<Bytes, reqwest::Error> {
     let res = client.get(HN_500_URL).send().await?.bytes().await?;
 


### PR DESCRIPTION
## Summary
- clarify README to mention fetching newest stories with ≥500 points
- update client module docs to describe retrieving new ≥500-point stories

## Testing
- `cargo fmt --all`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6890c1e625508320903ec0b9bca02410