### PR TITLE
test: verify truncation removes old items

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -174,6 +174,8 @@ mod tests {
         instance.whats_new(items);
 
         assert_eq!(instance.history.len(), 100);
+        assert_eq!(instance.items.len(), 100);
+        assert!(!instance.items.iter().any(|item| item.guid == "0"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- enhance truncation test to confirm history and item set limited to 100
- assert early GUIDs are removed after truncation

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6890c1e76b008320be02309ab6ccd153